### PR TITLE
Add a function to extend scheme's color array

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All available options are listed below.
 | `fillAlpha` | `Number` | `0.5` | The transparency value for the line fill color. Must be a number between `0.0` (fully transparent) and `1.0` (no transparency).
 | `scheme` | `String` | `'brewer.Paired12'` | Color scheme name that is any of [Color Chart](https://nagix.github.io/chartjs-plugin-colorschemes/colorchart.html).
 | `reverse` | `Boolean` | `false` | If set to `true`, the order of the colors in the selected  scheme is reversed.
-| `custom` | `Function` | undefined | A function that takes a copy of `scheme` in order to extend the predefined scheme colors. [more...](#custom-function).
+| `custom` | `Function` | undefined | A function that takes a copy of the color string array for `scheme` in order to extend the predefined scheme colors. [more...](#custom-function).
 
 ### `custom`-Function
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All available options are listed below.
 | `fillAlpha` | `Number` | `0.5` | The transparency value for the line fill color. Must be a number between `0.0` (fully transparent) and `1.0` (no transparency).
 | `scheme` | `String` | `'brewer.Paired12'` | Color scheme name that is any of [Color Chart](https://nagix.github.io/chartjs-plugin-colorschemes/colorchart.html).
 | `reverse` | `Boolean` | `false` | If set to `true`, the order of the colors in the selected  scheme is reversed.
-| `custom` | `Function` | undefined | A function that takes a copy of `scheme` in order to extend the predefined scheme colors (see example below).
+| `custom` | `Function` | undefined | A function that takes a copy of `scheme` in order to extend the predefined scheme colors. [more...](#custom-function).
 
 ### `custom`-Function
 
@@ -93,7 +93,7 @@ var customColorFunction = function (schemeColors) {
     return schemeColors;
 };
 
-...
+// ...
     options: {
     	plugins: {
             colorschemes: {
@@ -102,7 +102,7 @@ var customColorFunction = function (schemeColors) {
             }
         }
     }
-...
+//...
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All available options are listed below.
 | `fillAlpha` | `Number` | `0.5` | The transparency value for the line fill color. Must be a number between `0.0` (fully transparent) and `1.0` (no transparency).
 | `scheme` | `String` | `'brewer.Paired12'` | Color scheme name that is any of [Color Chart](https://nagix.github.io/chartjs-plugin-colorschemes/colorchart.html).
 | `reverse` | `Boolean` | `false` | If set to `true`, the order of the colors in the selected  scheme is reversed.
-| `custom` | `Function` | undefined | A function that takes a copy of the color string array for `scheme` in order to extend the predefined scheme colors. [more...](#custom-function).
+| `custom` | `Function` | `undefined` | A function that takes a copy of the color string array for `scheme` in order to extend the predefined scheme colors. [more...](#custom-function).
 
 ### `custom`-Function
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,34 @@ All available options are listed below.
 | `fillAlpha` | `Number` | `0.5` | The transparency value for the line fill color. Must be a number between `0.0` (fully transparent) and `1.0` (no transparency).
 | `scheme` | `String` | `'brewer.Paired12'` | Color scheme name that is any of [Color Chart](https://nagix.github.io/chartjs-plugin-colorschemes/colorchart.html).
 | `reverse` | `Boolean` | `false` | If set to `true`, the order of the colors in the selected  scheme is reversed.
+| `custom` | `Function` | undefined | A function that takes a copy of `scheme` in order to extend the predefined scheme colors (see example below).
+
+### `custom`-Function
+
+With the help of the `custom`-Function you can extend the predefined scheme colors. This function takes a copy of the current scheme and has to return an array with at least one element. See the example below:
+
+```js
+var customColorFunction = function (schemeColors) {
+    var myColors = ['#ff0000', '#00ff00', '#0000ff']; // define/generate own colors
+
+    // extend the color scheme with own colors
+    Array.prototype.push.apply(schemeColors, myColors);
+
+    return schemeColors;
+};
+
+...
+    options: {
+    	plugins: {
+            colorschemes: {
+                scheme: 'brewer.Paired12'
+                custom: customColorFunction
+            }
+        }
+    }
+...
+
+```
 
 ## Building
 

--- a/src/plugins/plugin.colorschemes.js
+++ b/src/plugins/plugin.colorschemes.js
@@ -20,30 +20,32 @@ export default {
 	beforeUpdate: function(chart, options) {
 		var s = options.scheme.split('.');
 		var category = colorschemes[s[0]];
-		var scheme, length, colorIndex, color, colorFunctionResult;
+		var scheme, schemeClone, length, colorIndex, color;
 
 		if (category) {
 			scheme = category[s[1]];
 
-			if (options.colorFunction) {
-				// Execute own color function
-				colorFunctionResult = options.colorFunction();
+			if (scheme) {
 
-				if (colorFunctionResult instanceof Array) {
-					if (scheme) {
-						// Add own colors to the predifined scheme
-						Array.prototype.push.apply(scheme, colorFunctionResult);
+				// clone the original scheme
+				schemeClone = JSON.parse(JSON.stringify(scheme));
+
+				if (options.custom) {
+					// Execute own custom color function
+					var colorFunctionResult = options.custom(schemeClone);
+
+					// check if we really received a filled array; otherwise we keep and use the originally cloned scheme
+					if (colorFunctionResult instanceof Array && colorFunctionResult.length > 0) {
+						schemeClone = colorFunctionResult;
 					}
 				}
-			}
 
-			length = scheme.length;
+				length = schemeClone.length;
 
-			if (scheme) {
 				// Set scheme colors
 				chart.config.data.datasets.forEach(function(dataset, datasetIndex) {
 					colorIndex = datasetIndex % length;
-					color = scheme[options.reverse ? length - colorIndex - 1 : colorIndex];
+					color = schemeClone[options.reverse ? length - colorIndex - 1 : colorIndex];
 
 					// Object to store which color option is set
 					dataset.colorschemes = {};
@@ -76,7 +78,7 @@ export default {
 						if (typeof dataset.backgroundColor === 'undefined') {
 							dataset.backgroundColor = dataset.data.map(function(data, dataIndex) {
 								colorIndex = dataIndex % length;
-								return scheme[options.reverse ? length - colorIndex - 1 : colorIndex];
+								return schemeClone[options.reverse ? length - colorIndex - 1 : colorIndex];
 							});
 							dataset.colorschemes.backgroundColor = true;
 						}

--- a/src/plugins/plugin.colorschemes.js
+++ b/src/plugins/plugin.colorschemes.js
@@ -20,11 +20,25 @@ export default {
 	beforeUpdate: function(chart, options) {
 		var s = options.scheme.split('.');
 		var category = colorschemes[s[0]];
-		var scheme, length, colorIndex, color;
+		var scheme, length, colorIndex, color, colorFunctionResult;
 
 		if (category) {
 			scheme = category[s[1]];
+
+			if (options.colorFunction) {
+				// Execute own color function
+				colorFunctionResult = options.colorFunction();
+
+				if (colorFunctionResult instanceof Array) {
+					if (scheme) {
+						// Add own colors to the predifined scheme
+						Array.prototype.push.apply(scheme, colorFunctionResult);
+					}
+				}
+			}
+
 			length = scheme.length;
+
 			if (scheme) {
 				// Set scheme colors
 				chart.config.data.datasets.forEach(function(dataset, datasetIndex) {

--- a/src/plugins/plugin.colorschemes.js
+++ b/src/plugins/plugin.colorschemes.js
@@ -30,14 +30,12 @@ export default {
 				// clone the original scheme
 				schemeClone = scheme.slice();
 
-				if (options.custom) {
-					// Execute own custom color function
-					var colorFunctionResult = options.custom(schemeClone);
+				// Execute own custom color function
+				var colorFunctionResult = helpers.callback(options.custom, [schemeClone]);
 
-					// check if we really received a filled array; otherwise we keep and use the originally cloned scheme
-					if (colorFunctionResult instanceof Array && colorFunctionResult.length > 0) {
-						schemeClone = colorFunctionResult;
-					}
+				// check if we really received a filled array; otherwise we keep and use the originally cloned scheme
+				if (colorFunctionResult instanceof Array && colorFunctionResult.length > 0) {
+					schemeClone = colorFunctionResult;
 				}
 
 				length = schemeClone.length;

--- a/src/plugins/plugin.colorschemes.js
+++ b/src/plugins/plugin.colorschemes.js
@@ -34,7 +34,7 @@ export default {
 				var colorFunctionResult = helpers.callback(options.custom, [schemeClone]);
 
 				// check if we really received a filled array; otherwise we keep and use the originally cloned scheme
-				if (colorFunctionResult instanceof Array && colorFunctionResult.length > 0) {
+				if (helpers.isArray(colorFunctionResult) && colorFunctionResult.length > 0) {
 					schemeClone = colorFunctionResult;
 				}
 

--- a/src/plugins/plugin.colorschemes.js
+++ b/src/plugins/plugin.colorschemes.js
@@ -28,7 +28,7 @@ export default {
 			if (scheme) {
 
 				// clone the original scheme
-				schemeClone = JSON.parse(JSON.stringify(scheme));
+				schemeClone = scheme.slice();
 
 				if (options.custom) {
 					// Execute own custom color function


### PR DESCRIPTION
You can add a new option called `custom` which should be a function that receives a clone of the configured scheme and has to return an array of colors.
If no or an empty array is returned the original scheme is used.