### PR TITLE
Fix Chart.js v3 compatibility

### DIFF
--- a/src/plugins/plugin.colorschemes.js
+++ b/src/plugins/plugin.colorschemes.js
@@ -181,6 +181,8 @@ var ColorSchemesPlugin = {
 	}
 };
 
-Chart.plugins.register(ColorSchemesPlugin);
+// Chart.js v3 uses "Chart.register", while v2 uses "Chart.plugins.register"
+const registerPlugin = Chart.register || Chart.plugins.register;
+registerPlugin(ColorSchemesPlugin);
 
 export default ColorSchemesPlugin;


### PR DESCRIPTION
Chart.js seems to use `Chart.register`, while v2 uses `Chart.plugins.register`.
This fixes registering the Color Schemes Plugin in Chart.js v3.